### PR TITLE
Fix failed Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "3.6"
-  - "3.7-dev"
 # install dependencies
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
# Fix failed Travis build

## Issue

Travis build 14 failed.  It was unable to access Python 3.7-dev.

[Travis log](https://travis-ci.org/growwithgooglema/mbtaccess/jobs/410098818)

```text
# Worker information
# Build system information
Network availability confirmed.
3.7-dev is not installed; attempting download
Downloading archive: https://s3.amazonaws.com/travis-python-archives/binaries/ubuntu/14.04/x86_64/python-3.7-dev.tar.bz2
$ curl -sSf -o python-3.7-dev.tar.bz2 ${archive_url}
curl: (35) Unknown SSL protocol error in connection to s3.amazonaws.com:443 
Unable to download 3.7-dev archive. The archive may not exist. Please consider a different version.
```

## Bugfix

Python 3.7-dev removed from .travis.yml.