### PR TITLE
Build local Docker container for app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -83,8 +83,8 @@ celerybeat-schedule
 .env
 
 # virtualenv
-.venv
-venv/
+.venv*
+venv*/
 ENV/
 
 # Spyder project settings
@@ -109,8 +109,8 @@ ENV/
 # Node Modules
 node_modules/
 
-# Test DB
-test_database.sqlite
+# Database
+*.sqlite
 
 # Some other info
 *.gpg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM python
+FROM python:3.7-alpine
 
-COPY . /src/.
+LABEL Name=mbtaccess Version=0.2.0
+EXPOSE 80
+ENV APP_PORT 80
+ENV APP_HOST '0.0.0.0'
 
-EXPOSE 8000
+WORKDIR /app
+ADD . /app
 
-WORKDIR /src/
-CMD python3 -m http.server 8000
+RUN python3 -m pip install -r requirements.txt
+RUN python3 migrate.py
+CMD ["python3", "app.py"]

--- a/README.md
+++ b/README.md
@@ -103,25 +103,37 @@ The Flask application should run within a virtual environment. Python 3 is bundl
 
 ### Docker
 
-The application is assembled into a Docker container, and is available as a container image on Docker Hub. Docker Hub rebuilds the container after each commit to the `master` branch.
+The application is assembled into a [Docker](https://www.docker.com/) container.
 
-1. **Pull Docker container image**:
+- An **image** is the executable set of files used by Docker.
+- A **container** is a running image.
+- The [Dockerfile](https://docs.docker.com/get-started/part2/#define-a-container-with-dockerfile) tells Docker how to build the container.
+- Visual Studio Code has built-in Docker features. See [Working with Docker in VS Code](https://code.visualstudio.com/docs/azure/docker).
+
+To build and run the Docker application container locally:
+
+1. Clone, or fork and clone, the GitHub repository to your machine.
+2. [Install Docker Desktop](https://www.docker.com/products/docker-desktop) on your machine.
+3. Build and run the container.
 
     ```sh
-    docker pull growwithgooglema/gwg-mbta:latest
+    docker build -t mbtaccess .
+    docker run -d -p 80:80 mbtaccess:latest
     ```
 
-2. **Run Docker container locally**:
+    `-p 80:80` maps the http port 80 from your local machine to port 80 on the container. Ports other than `80` can be used by modifying the Dockerfile.
+
+    Other useful commands:
 
     ```sh
-    docker run -d -p 80:8000 growwithgooglema/gwg-mbta:latest
+    docker container ls
+    docker container stop <SHA or container name>
+    docker container rm <SHA or container name>
+    docker image ls
+    docker image rm <SHA or container name>
     ```
 
-    - `-p 80:8000` maps the http port 80 from your local machine to port 8000 on the container.
-    - Local ports other than 80 can be used.
-    - Container ports other than 8000 can be used if the Dockerfile is modified for the new http server listener port.
-
-3. **Run application**: To check if the application is running correctly, open a web browser and navigate to [http://localhost:80](http://localhost:80).
+4. Browse to [http://localhost:80](http://localhost:80) to see the app.
 
 ### Testing
 

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+services:
+  mbtaccess:
+    image: mbtaccess
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+        - 80:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2.1'
+
+services:
+  mbtaccess:
+    image: mbtaccess
+    build: .
+    ports:
+      - 80:80

--- a/migrate.py
+++ b/migrate.py
@@ -15,8 +15,8 @@ def main():
     if os.environ.get('DBASE_URL'):
         db_url = os.environ.get('DBASE_URL')
     else:
-        db_url = "sqlite:///{p}".format(
-            p=os.path.join(os.path.dirname(__file__), "test_database.sqlite")
+        db_url = 'sqlite:///{p}'.format(
+            p=os.path.join(os.path.dirname(__file__), 'stops.sqlite')
         )
     app.config['SQLALCHEMY_DATABASE_URI'] = db_url
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
@@ -24,10 +24,10 @@ def main():
     app.app_context().push()
     db.drop_all()
     db.create_all()
-    all_stops = Stop.from_api("https://api-v3.mbta.com/stops")
+    all_stops = Stop.from_api('https://api-v3.mbta.com/stops')
     db.session.bulk_save_objects(all_stops)
     db.session.commit()
-    print("Done loading data")
+    print('Done loading data')
 
 
 if __name__ == '__main__':

--- a/models.py
+++ b/models.py
@@ -77,8 +77,7 @@ class Stop(db.Model):
 
     def within_distance(self, point, distance=(1.609344)/2.0):
         """
-        Returns True if the distance between `self` and `point`
-        is less than or equal to half a mile.
+        Returns True if the distance between `self` and `point` is ≤0.5 miles.
 
         :param point: a python dictionary with keys lat and lon corresponding to a geo position
         :type: dict
@@ -96,9 +95,8 @@ class Stop(db.Model):
     @classmethod
     def from_api(cls, url):
         """
-        Given the URL endpoint to the MBTA stops API,
-        the function should fetch all the stops and generate Stop
-        objects with said stops.
+        Given the URL endpoint to the MBTA stops API, the function should fetch all stops
+        and generate Stop objects from stops.
 
         :param url: The endpoint for the stops API
         :type: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ Flask-SQLAlchemy==2.3.2
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0
-psycopg2==2.7.5
 SQLAlchemy==1.2.10
 Werkzeug==0.14.1

--- a/static/js/google-maps.js
+++ b/static/js/google-maps.js
@@ -75,7 +75,7 @@ async function initMap () {
                 <header>
                   <strong>${number}. ${name}</strong>
                 </header>
-                <div><a href="${googleUrl}">View on Google Maps</a></div>
+                <div><a href="${googleUrl}" target="_blank">View on Google Maps</a></div>
               </div>`)
             infoWindow.open(map, marker)
           })

--- a/static/js/google-maps.js
+++ b/static/js/google-maps.js
@@ -24,7 +24,7 @@ async function initMap () {
       infoWindow.setContent(location.name)
       infoWindow.open(map, marker)
       // Fetch stops near location from database
-      const query = fetch(`http://localhost:5000/stops?lat=${location.lat}&lon=${location.lng}`)
+      const query = fetch(`stops?lat=${location.lat}&lon=${location.lng}`)
       const data = await (await query).json()
       const stops = data.stops
       if (stops.length !== 0) {

--- a/static/js/universities.js
+++ b/static/js/universities.js
@@ -13,7 +13,7 @@ async function initMap () {
     google.maps.event.addDomListener(window, 'resize', () => map.fitBounds(bounds))
     const infoWindow = new google.maps.InfoWindow()
     // Fetch university data
-    const query = fetch('data/cleaner_universities.json')
+    const query = fetch('universities/data')
     const universities = await (await query).json()
     // Create table that will be populated with universities
     const tableDiv = document.getElementById('universities-table')

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -17,7 +17,7 @@ from app import app, db
 if os.environ.get('DBASE_URL'):
     db_url = os.environ.get('DBASE_URL')
 else:
-    db_url = "sqlite:///{p}".format(p=os.path.join(main_dir, "test_database.sqlite"))
+    db_url = 'sqlite:///{p}'.format(p=os.path.join(main_dir, 'stops.sqlite'))
 
 
 class AppTest(unittest.TestCase):
@@ -40,14 +40,15 @@ class AppTest(unittest.TestCase):
             'index.html': 404,
             '/': 200,
             '/sw.js': 200,
-            '/data/cleaner_universities.json': 200,
             '/universities.html': 404,
             '/universities': 200,
+            '/data/cleaner_universities.json': 404,
+            '/universities/data': 200,
             '/stops?lat=42.35947&lon=-71.09296': 200,
             '/stop/5': 200,
         }
         for e, exp in endpoints.items():
-            with self.subTest("Testing endpoint {e}".format(e=e), end=e, expect=exp):
+            with self.subTest('Testing endpoint {e}'.format(e=e), end=e, expect=exp):
                 self.assertEqual(self.client.get(e).status_code, exp)
 
     def test_stop(self):
@@ -59,7 +60,7 @@ class AppTest(unittest.TestCase):
             '/stop/225': 'good',
         }
         for e, exp in endpoints.items():
-            with self.subTest("Testing API endpoint {e}".format(e=e), end=e, expect=exp):
+            with self.subTest('Testing API endpoint {e}'.format(e=e), end=e, expect=exp):
                 data = json.loads(self.client.get(e).data.decode('utf8'))
                 self.assertEqual(data.get('status'), exp)
 
@@ -73,7 +74,7 @@ class AppTest(unittest.TestCase):
             '/stops?lat=42.36947&lon=-71.08296': 'good'
         }
         for e, exp in endpoints.items():
-            with self.subTest("Testing API endpoint {e}".format(e=e), end=e, expect=exp):
+            with self.subTest('Testing API endpoint {e}'.format(e=e), end=e, expect=exp):
                 data = json.loads(self.client.get(e).data.decode('utf8'))
                 # Test for equality
                 self.assertEqual(data.get('status'), exp)

--- a/tests/utilities_test.py
+++ b/tests/utilities_test.py
@@ -19,10 +19,10 @@ class UtilitiesTest(unittest.TestCase):
 
     def setUp(self):
         """Set up test variables"""
-        self.bad_url = "https://api-v3.mbta.com/stopping"
-        self.good_url = "https://api-v3.mbta.com/stops"
-        self.good_path = os.path.join(main_dir, "data", "universities.json")
-        self.bad_path = os.path.join(main_dir, "data", "bad_universities.json")
+        self.bad_url = 'https://api-v3.mbta.com/stopping'
+        self.good_url = 'https://api-v3.mbta.com/stops'
+        self.good_path = os.path.join(main_dir, 'data', 'universities.json')
+        self.bad_path = os.path.join(main_dir, 'data', 'bad_universities.json')
         self.point1 = {'lat': 42.36947, 'lon': -71.08296}
         self.point2 = {'lat': 41.76947, 'lon': -72.12296}
 


### PR DESCRIPTION
# Build local Docker container for app

[Docker](https://www.docker.com/) is a useful tool that bundles applications and their dependencies into independent containers. The commits in this pull request enable the main application to be built into a Docker container. This PR is a re-do of PR #46  on a cleaner branch (after merging #45) and addresses issue #20.

## Changes

- Rewrite Dockerfile for new app stack
  - Further info on Dockerfile syntax can be found in the [Docker getting started docs](https://docs.docker.com/get-started/part2/#dockerfile) and [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).
  - Visual Studio Code has built-in Docker features. See [Working with Docker in VS Code](https://code.visualstudio.com/docs/azure/docker).
- Add Docker Compose files for future integration with multiple Docker containers
- Update Python files for Docker
  - Rename database to *stops.db*
  - Change endpoint for university data from */data/cleaner_universities.json* to *universities/data*
  - Specify host in *app.py* with environment variable option
  - Unify string formatting: Demarcate strings with single quotes unless single quote occurs within string
  - Regenerate *requirements.txt*
- Update JavaScript files
  - Update JavaScript fetch URLs to match Docker and Python changes
- Update README with new Docker info

## Instructions

To build and run the Docker application container locally:

1. Pull the `docker` branch from the GitHub repository to your machine.

    ```sh
    cd path/to/mbtaccess/repo
    git pull origin docker2
    ```

2. [Install Docker Desktop](https://www.docker.com/products/docker-desktop) on your machine. I recommend installing via Homebrew cask.

    ```sh
    brew cask install docker
    ```

3. Build and run the container.

    ```sh
    docker build -t mbtaccess .
    docker run -d -p 80:80 mbtaccess:latest
    ```

    Including `-t mbtaccess` will tag the build for easier identification. `-p 80:80` maps the http port 80 from your local machine to port 80 on the container. Ports other than `80` can be used by modifying the Dockerfile.

    Other useful commands:

    ```sh
    docker container ls
    docker container stop <SHA or container name>
    docker container rm <SHA or container name>
    docker image ls
    docker image rm <SHA or container name>
    ```

4. Browse to [http://localhost:80](http://localhost:80) to see the app.

## Next steps

This Docker container is not being autobuilt by Docker Cloud yet. Once we merge this PR into `dev`, we can configure Docker Cloud to autobuild containers again.

The next steps will be adding multiple Docker containers, and integrating the containers with Docker Compose.

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/growwithgooglema/mbtaccess/blob/dev/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/growwithgooglema/mbtaccess/blob/dev/CODE_OF_CONDUCT.md).