### PR TITLE
Merge Jinja2 patch from dev

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click==6.7
 Flask==1.0.2
 Flask-SQLAlchemy==2.3.2
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.0
 SQLAlchemy==1.2.10
 Werkzeug==0.14.1


### PR DESCRIPTION
# Patch Jinja2 security vulnerability

Upgrade to Jinja2 = ">=2.10.1"

Details:
CVE-2019-10906
high severity
Vulnerable versions: < 2.10.1
Patched version: 2.10.1
In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.
More information: https://nvd.nist.gov/vuln/detail/CVE-2019-10906

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/growwithgooglema/mbtaccess/blob/dev/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/growwithgooglema/mbtaccess/blob/dev/CODE_OF_CONDUCT.md).